### PR TITLE
Grey out finished pools and change time format

### DIFF
--- a/src/config/constants/pools.ts
+++ b/src/config/constants/pools.ts
@@ -1,5 +1,5 @@
 import tokens from './tokens'
-import { PoolConfig, PoolCategory  } from './types'
+import { PoolConfig, PoolCategory } from './types'
 
 const pools: PoolConfig[] = [
   // {

--- a/src/views/Pools/components/PoolCard/CardActions/ApprovalAction.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/ApprovalAction.tsx
@@ -6,6 +6,7 @@ import { useERC20 } from 'hooks/useContract'
 import useToast from 'hooks/useToast'
 import { getAddress } from 'utils/addressHelpers'
 import { Pool } from 'state/types'
+import { useTimestamp } from 'state/hooks'
 
 interface ApprovalActionProps {
   pool: Pool
@@ -14,12 +15,14 @@ interface ApprovalActionProps {
 
 
 const ApprovalAction: React.FC<ApprovalActionProps> = ({ pool, isLoading = false }) => {
-  const { sousId, stakingToken, earningToken, isFinished } = pool
+  const { sousId, stakingToken, earningToken, endBlock } = pool
   const { t } = useTranslation()
   const stakingTokenContract = useERC20(stakingToken.address ? getAddress(stakingToken.address) : '')
   const [requestedApproval, setRequestedApproval] = useState(false)
   const { onApprove } = useSousApprove(stakingTokenContract, sousId)
   const { toastSuccess, toastError } = useToast()
+  const currentBlock = useTimestamp()
+  const isFinished = pool.isFinished || (Math.max(endBlock - currentBlock, 0) === 0)
 
   const handleApprove = useCallback(async () => {
     try {

--- a/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import { useTranslation } from 'contexts/Localization'
 import { getBalanceNumber, formatNumber, getDecimalAmount } from 'utils/formatBalance'
 import { Pool } from 'state/types'
+import { useTimestamp } from 'state/hooks'
 import NotEnoughTokensModal from '../Modals/NotEnoughTokensModal'
 import StakeModal from '../Modals/StakeModal'
 
@@ -26,7 +27,8 @@ const StakeAction: React.FC<StakeActionsProps> = ({
   isStaked,
   isLoading = false,
 }) => {
-  const { stakingToken, earningToken, stakingLimit, isFinished } = pool
+  const currentBlock = useTimestamp()
+  const { stakingToken, earningToken, stakingLimit, endBlock } = pool
   const { t } = useTranslation()
   const convertedLimit = getDecimalAmount(new BigNumber(stakingLimit), earningToken.decimals)
   const stakingMax =
@@ -35,6 +37,7 @@ const StakeAction: React.FC<StakeActionsProps> = ({
   const stakingMaxDollarValue = formatNumber(
     getBalanceNumber(stakedBalance.multipliedBy(stakingTokenPrice), stakingToken.decimals),
   )
+  const isFinished = pool.isFinished || (Math.max(endBlock - currentBlock, 0) === 0)
 
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
 

--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -53,20 +53,27 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({
   const imageSrc = `${BASE_URL}/images/tokens/${earningToken.symbol.toLowerCase()}.png`
   const isMetaMaskInScope = !!(window as WindowChain).ethereum?.isMetaMask
 
-  const shouldShowBlockCountdown = Boolean(!isFinished && startBlock && endBlock)
   const blocksUntilStart = Math.max(startBlock - currentBlock, 0)
   const minutesUntilStart = blocksUntilStart / 60
-  const hoursUntilStart = minutesUntilStart / 60
   const blocksRemaining = Math.max(endBlock - currentBlock, 0)
   const minutesRemaining = blocksRemaining / 60
-  const hoursRemaining = minutesRemaining / 60
   const hasPoolStarted = blocksUntilStart === 0 && blocksRemaining > 0
+  const shouldShowBlockCountdown = Boolean((!isFinished && blocksRemaining !== 0) && startBlock && endBlock)
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     t('Subtracted automatically from each yield harvest and burned.'),
     { placement: 'bottom-end' },
   )
 
+  function formatTime(minutes) {
+    const days = Math.floor(minutes / 1440);
+    const hours = Math.floor(minutes / 60) % 24;
+    const formattedMinutes = Math.floor(minutes % 60);
+    const showD = days > 0;
+    const showH = hours > 0 || showD;
+    const showM = formattedMinutes > 0 || showH;
+    return `${showD ? `${days}d` : ''} ${showH ? `${hours}h` : ''} ${showM ? `${formattedMinutes}m` : ''}`;
+  }
 
   return (
     <ExpandedWrapper flexDirection="column">
@@ -97,22 +104,21 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({
           <Text small>{hasPoolStarted ? t('End') : t('Start')}:</Text>
           <Flex alignItems="center">
             {blocksRemaining || blocksUntilStart ? (
-              <Balance
-                color="text"
-                fontSize="14px"
-                value={hasPoolStarted ? hoursRemaining : hoursUntilStart}
-                decimals={0}
-              />
+              <Text bold fontSize="14px" color="text" small>
+                {hasPoolStarted ? formatTime(minutesRemaining) : formatTime(minutesUntilStart)}
+              </Text>
             ) : (
               <Skeleton width="54px" height="21px" />
             )}
-            <Text ml="4px" color="text" small>
-              {t('hours')}
-            </Text>
             <TimerIcon ml="4px" color="secondary" />
           </Flex>
         </Flex>
       )}
+      {/* {!shouldShowBlockCountdown && (
+        <Text bold>
+          finished
+        </Text>
+      )} */}
       {isAutoVault && (
         <Flex mb="2px" justifyContent="space-between" alignItems="center">
           {tooltipVisible && tooltip}
@@ -127,7 +133,7 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({
         </Flex>
       )}
       <Flex mb="2px" justifyContent="flex-end">
-        <LinkExternal color="text"bold={false} small href={earningToken.projectLink}>
+        <LinkExternal color="text" bold={false} small href={earningToken.projectLink}>
           {t('View Project Site')}
         </LinkExternal>
       </Flex>

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -5,7 +5,7 @@ import UnlockButton from 'components/UnlockButton'
 import { useTranslation } from 'contexts/Localization'
 // import { getAddress } from 'utils/addressHelpers'
 import { BIG_ZERO } from 'utils/bigNumber'
-import { usePriceCakeBusd } from 'state/hooks'
+import { usePriceCakeBusd, useTimestamp } from 'state/hooks'
 import { Pool } from 'state/types'
 import AprRow from './AprRow'
 import StyledCard from './StyledCard'
@@ -14,16 +14,18 @@ import StyledCardHeader from './StyledCardHeader'
 import CardActions from './CardActions'
 
 const PoolCard: React.FC<{ pool: Pool; account: string; isHomeCard?: boolean }> = ({ pool, account, isHomeCard }) => {
-  const { sousId, stakingToken, earningToken, isFinished, userData } = pool
+  const currentBlock = useTimestamp()
+  const { sousId, stakingToken, earningToken, endBlock, userData } = pool
   const { t } = useTranslation()
   const stakedBalance = userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO
   const accountHasStakedBalance = stakedBalance.gt(0)
   const stakingTokenPrice = usePriceCakeBusd().toNumber()
+  const isFinished = pool.isFinished || (Math.max(endBlock - currentBlock, 0) === 0)
 
   return (
     <StyledCard
       isStaking={!isFinished && accountHasStakedBalance}
-      isFinished={isFinished && sousId !== 0}
+      isFinished={(isFinished && sousId !== 0)}
       ribbon={isFinished && <CardRibbon variantColor="textDisabled" text={`${t('Finished')}`} />}
       isHomeCard={isHomeCard}
     >

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -22,7 +22,7 @@ const Pools: React.FC = () => {
   const { account } = useWeb3React()
   const pools = usePools(account)
   const { currentBlock } = useBlock()
-  const [stakedOnly, setStakedOnly] = usePersistState(false,  { localStorageKey: 'morpheus_pool_staked' })
+  const [stakedOnly, setStakedOnly] = usePersistState(false, { localStorageKey: 'morpheus_pool_staked' })
 
   const [finishedPools, openPools] = useMemo(
     () => partition(pools, (pool) => pool.isFinished || currentBlock > pool.endBlock),
@@ -71,11 +71,11 @@ const Pools: React.FC = () => {
               {/* <LydVaultCard pool={lydPoolData} showStakedOnly={stakedOnly} /> */}
               {stakedOnly
                 ? orderBy(stakedOnlyPools, ['sortOrder']).map((pool) => (
-                    <PoolCard key={pool.sousId} pool={pool} account={account} />
-                  ))
+                  <PoolCard key={pool.sousId} pool={pool} account={account} />
+                ))
                 : orderBy(openPools, ['sortOrder']).map((pool) => (
-                    <PoolCard key={pool.sousId} pool={pool} account={account} />
-                  ))}
+                  <PoolCard key={pool.sousId} pool={pool} account={account} />
+                ))}
             </>
           </Route>
           <Route path={`${path}/history`}>


### PR DESCRIPTION
Finished NEO pools will be greyed out (unable to click stake or enable, but able to harvest and withdraw) and will remain in NEO pools Live tab until manually changed to finished.

This will allow ppl to see at a glance most recent finished pools and react.

Also timer was changed to show time with minutes precision and better format.